### PR TITLE
Screen Rotation & Cursor Placement

### DIFF
--- a/show_main/show_main.ino
+++ b/show_main/show_main.ino
@@ -494,6 +494,14 @@ int parsechar(unsigned char current_char)
                         case 'r':    //rotation
                                 rotation = tmpnum;
                                 tft.setRotation(rotation);
+                                if (rotation == 0 || rotation == 2) {   // Portrait mode
+                                        bottom_edge0 = RIGHT_EDGE320;
+                                        right_edge0 = BOTTOM_EDGE240;
+                                }
+                                else {                                  // Landscape mode
+                                        bottom_edge0 = BOTTOM_EDGE240;
+                                        right_edge0 = RIGHT_EDGE320;
+                                }
                                 break;
 
                         case 'm':


### PR DESCRIPTION
This change fixes an issue that occurs when using the screen in "portrait" mode, it simply checks the new rotation value whenever it is changed and updates the variables used for the screens edge/size to the correct value. This fixes cursor placement issues when in "portrait" mode which wouldn't allow the cursor to be placed below 240px (the height in "landscape" mode) when using the `cursorDown` method or any of the ANSI/VT100 codes for cursor movement.